### PR TITLE
Remove early stopping when there are enough hypotheses

### DIFF
--- a/beam_search.py
+++ b/beam_search.py
@@ -84,7 +84,7 @@ def beam_search(initial_state_function, generate_function, X, start_id, end_id, 
             else:
                 fringe.append(n)
 
-        if not fringe or len(hypotheses) >= num_hypotheses:
+        if not fringe:
             break
 
         Y_tm1 = np.array([n.value for n in fringe], dtype=np.int32)


### PR DESCRIPTION
This can cause larger beam sizes to perform worst than smaller ones. 
Let's assume when we use greedy search (beam_width= 1, num_hypothesis=1) we get legal hypothesis (ends with end_id) with length 5. Using larger beam size we may encounter more short legal hypotheses (for example length 3 or 4), which we haven't encountered with greedy search. Let's assume all those hypotheses are worst than the original one. Those hypotheses can fill the hypotheses list before we reach the original one, and we end the search. Therefore, when using larger beam_width we got worst performance.
The solution is to continue going until max_length instead of early stopping.